### PR TITLE
feat: Auto-generate assets.json and enable direct asset URLs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node.js (for fallback)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Generate assets.json if missing (fallback)
+        run: |
+          if [ ! -f "assets.json" ]; then
+            echo "assets.json missing, generating as fallback..."
+            node scripts/generate-assets.js || echo "Generation failed, continuing..."
+          fi
       - name: Create symlinks for direct access
         run: |
           mkdir -p icons logos images

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -1,0 +1,43 @@
+name: Update Assets JSON
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'assets/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate assets.json
+        run: |
+          node scripts/generate-assets.js
+
+      - name: Commit and push if changed
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add assets.json
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "Auto-update: Regenerate assets.json from filesystem"
+            git push
+            echo "ASSETS_UPDATED=true" >> $GITHUB_ENV
+          else
+            echo "No changes to assets.json"
+            echo "ASSETS_UPDATED=false" >> $GITHUB_ENV
+          fi

--- a/assets.json
+++ b/assets.json
@@ -4,174 +4,293 @@
       "name": "aws-black-icon",
       "type": "icon",
       "path": "assets/icons/aws-black.svg",
+      "tags": [
+        "aws",
+        "black",
+        "icon"
+      ],
       "size": 64,
-      "tags": ["aws", "icon"],
-      "description": "AWS Black icon asset (64x64)"
+      "description": "aws black icons (48×48)"
     },
     {
       "name": "aws-black-orange-icon",
       "type": "icon",
       "path": "assets/icons/aws-black-orange.svg",
+      "tags": [
+        "aws",
+        "black",
+        "icon",
+        "orange"
+      ],
       "size": 64,
-      "tags": ["aws", "icon", "black", "orange"],
-      "description": "AWS Black and Orange icon asset (64x64)"
-    },
-    {
-      "name": "aws-blue-orange-icon",
-      "type": "icon",
-      "path": "assets/icons/aws-blue-orange.svg",
-      "size": 64,
-      "tags": ["aws", "icon", "black"],
-      "description": "AWS Blue and Orange icon asset (64x64)"
-    },
-    {
-      "name": "aws-white-orange-icon",
-      "type": "icon",
-      "path": "assets/icons/aws-white-orange.svg",
-      "size": 64,
-      "tags": ["aws", "icon", "white", "orange"],
-      "description": "AWS White and Orange icon asset (64x64)"
-    },
-    {
-      "name": "aws-black-sphere-logo",
-      "type": "logo",
-      "path": "assets/logos/aws-black-sphere.svg",
-      "size": 375,
-      "tags": ["aws", "logo", "black", "sphere"],
-      "description": "AWS Black Sphere logo (375×375, viewBox)"
+      "description": "aws black orange icons (48×48)"
     },
     {
       "name": "aws-black-orange-sphere-logo",
       "type": "logo",
       "path": "assets/logos/aws-black-orange-sphere.svg",
-      "size": 375,
-      "tags": ["aws", "logo", "black", "orange", "sphere"],
-      "description": "AWS Black and Orange Sphere logo with black text and orange arrow (375×375, viewBox)"
+      "tags": [
+        "aws",
+        "black",
+        "logo",
+        "orange",
+        "sphere"
+      ],
+      "size": 500,
+      "description": "aws black orange sphere logos (500×500)"
+    },
+    {
+      "name": "aws-black-sphere-logo",
+      "type": "logo",
+      "path": "assets/logos/aws-black-sphere.svg",
+      "tags": [
+        "aws",
+        "black",
+        "logo",
+        "sphere"
+      ],
+      "size": 500,
+      "description": "aws black sphere logos (500×500)"
+    },
+    {
+      "name": "aws-blue-orange-icon",
+      "type": "icon",
+      "path": "assets/icons/aws-blue-orange.svg",
+      "tags": [
+        "aws",
+        "blue",
+        "icon",
+        "orange"
+      ],
+      "size": 64,
+      "description": "aws blue orange icons (48×48)"
     },
     {
       "name": "aws-blue-orange-sphere-logo",
       "type": "logo",
       "path": "assets/logos/aws-blue-orange-sphere.svg",
-      "size": 375,
-      "tags": ["aws", "logo", "blue", "orange", "sphere"],
-      "description": "AWS Blue and Orange Sphere logo with dark text #252f3e and orange arrow (375×375, viewBox)"
+      "tags": [
+        "aws",
+        "blue",
+        "logo",
+        "orange",
+        "sphere"
+      ],
+      "size": 500,
+      "description": "aws blue orange sphere logos (500×500)"
     },
     {
-      "name": "awscd-oceania-black-orange-icon",
+      "name": "aws-white-orange-icon",
       "type": "icon",
-      "path": "assets/icons/awscd-oceania-black-orange.svg",
+      "path": "assets/icons/aws-white-orange.svg",
+      "tags": [
+        "aws",
+        "icon",
+        "orange",
+        "white"
+      ],
       "size": 64,
-      "tags": ["aws", "icon", "oceania", "black", "orange"],
-      "description": "AWS CD Oceania Black and Orange icon asset (64x64)"
-    },
-    {
-      "name": "awscd-oceania-blue-orange-icon",
-      "type": "icon",
-      "path": "assets/icons/awscd-oceania-blue-orange.svg",
-      "size": 64,
-      "tags": ["aws", "icon", "oceania", "blue", "orange"],
-      "description": "AWS CD Oceania Blue and Orange icon asset with dark text #252f3e and orange elements (64x64)"
-    },
-    {
-      "name": "awscd-oceania-white-orange-icon",
-      "type": "icon",
-      "path": "assets/icons/awscd-oceania-white-orange.svg",
-      "size": 64,
-      "tags": ["aws", "icon", "oceania", "white", "orange"],
-      "description": "AWS CD Oceania White and Orange icon asset (64x64)"
-    },
-    {
-      "name": "awscd-oceania-black-black-sphere-logo",
-      "type": "logo",
-      "path": "assets/logos/awscd-oceania-black-black-sphere.svg",
-      "size": 375,
-      "tags": ["aws", "logo", "oceania", "black", "sphere"],
-      "description": "AWS CD Oceania Black Sphere logo with black text and black arrow (375×375, viewBox)"
-    },
-    {
-      "name": "awscd-oceania-black-orange-sphere-logo",
-      "type": "logo",
-      "path": "assets/logos/awscd-oceania-black-orange-sphere.svg",
-      "size": 375,
-      "tags": ["aws", "logo", "oceania", "black", "orange", "sphere"],
-      "description": "AWS CD Oceania Black and Orange Sphere logo with orange text and orange arrow (375×375, viewBox)"
-    },
-    {
-      "name": "awscd-oceania-blue-orange-sphere-logo",
-      "type": "logo",
-      "path": "assets/logos/awscd-oceania-blue-orange-sphere.svg",
-      "size": 375,
-      "tags": ["aws", "logo", "oceania", "blue", "orange", "sphere"],
-      "description": "AWS CD Oceania Blue and Orange Sphere logo with dark text #252f3e and orange elements (375×375, viewBox)"
+      "description": "aws white orange icons (48×48)"
     },
     {
       "name": "awscd-oceania-black-black-rectangle-logo",
       "type": "logo",
       "path": "assets/logos/awscd-oceania-black-black-rectangle.svg",
-      "size": 680,
-      "tags": ["aws", "logo", "oceania", "black", "rectangle"],
-      "description": "AWS CD Oceania Black Rectangle logo with black text and black arrow (680×280, viewBox)"
+      "tags": [
+        "awscd",
+        "black",
+        "logo",
+        "oceania",
+        "rectangle"
+      ],
+      "size": 906,
+      "description": "awscd oceania black black rectangle logos (906×906)"
     },
     {
-      "name": "awscd-oceania-blue-orange-rectangle-logo",
+      "name": "awscd-oceania-black-black-sphere-logo",
       "type": "logo",
-      "path": "assets/logos/awscd-oceania-blue-orange-rectangle.svg",
-      "size": 680,
-      "tags": ["aws", "logo", "oceania", "blue", "orange", "rectangle"],
-      "description": "AWS CD Oceania Blue and Orange Rectangle logo with dark text #252f3e and orange arrow (680×280, viewBox)"
-    },
-    {
-      "name": "awscd-oceania-white-white-rectangle-logo",
-      "type": "logo",
-      "path": "assets/logos/awscd-oceania-white-white-rectangle.svg",
-      "size": 680,
-      "tags": ["aws", "logo", "oceania", "white", "rectangle"],
-      "description": "AWS CD Oceania White Rectangle logo with white text and white arrow (680×280, viewBox)"
+      "path": "assets/logos/awscd-oceania-black-black-sphere.svg",
+      "tags": [
+        "awscd",
+        "black",
+        "logo",
+        "oceania",
+        "sphere"
+      ],
+      "size": 500,
+      "description": "awscd oceania black black sphere logos (500×500)"
     },
     {
       "name": "awscd-oceania-black-black-square-white-logo",
       "type": "logo",
       "path": "assets/logos/awscd-oceania-black-black-square-white.svg",
-      "size": 695,
-      "tags": ["aws", "logo", "oceania", "black", "square", "white"],
-      "description": "AWS CD Oceania Black Square logo with white background, black text and black arrow (695×280, viewBox)"
+      "tags": [
+        "awscd",
+        "black",
+        "logo",
+        "oceania",
+        "square",
+        "white"
+      ],
+      "size": 927,
+      "description": "awscd oceania black black square white logos (927×927)"
+    },
+    {
+      "name": "awscd-oceania-black-orange-icon",
+      "type": "icon",
+      "path": "assets/icons/awscd-oceania-black-orange.svg",
+      "tags": [
+        "awscd",
+        "black",
+        "icon",
+        "oceania",
+        "orange"
+      ],
+      "size": 64,
+      "description": "awscd oceania black orange icons (48×48)"
+    },
+    {
+      "name": "awscd-oceania-black-orange-sphere-logo",
+      "type": "logo",
+      "path": "assets/logos/awscd-oceania-black-orange-sphere.svg",
+      "tags": [
+        "awscd",
+        "black",
+        "logo",
+        "oceania",
+        "orange",
+        "sphere"
+      ],
+      "size": 500,
+      "description": "awscd oceania black orange sphere logos (500×500)"
     },
     {
       "name": "awscd-oceania-blue-blue-square-white-logo",
       "type": "logo",
       "path": "assets/logos/awscd-oceania-blue-blue-square-white.svg",
-      "size": 695,
-      "tags": ["aws", "logo", "oceania", "blue", "square", "white"],
-      "description": "AWS CD Oceania Blue Square logo with white background, dark text #252f3e and orange arrow (695×280, viewBox)"
+      "tags": [
+        "awscd",
+        "blue",
+        "logo",
+        "oceania",
+        "square",
+        "white"
+      ],
+      "size": 927,
+      "description": "awscd oceania blue blue square white logos (927×927)"
+    },
+    {
+      "name": "awscd-oceania-blue-orange-icon",
+      "type": "icon",
+      "path": "assets/icons/awscd-oceania-blue-orange.svg",
+      "tags": [
+        "awscd",
+        "blue",
+        "icon",
+        "oceania",
+        "orange"
+      ],
+      "size": 538,
+      "description": "awscd oceania blue orange icons (538×538)"
+    },
+    {
+      "name": "awscd-oceania-blue-orange-rectangle-logo",
+      "type": "logo",
+      "path": "assets/logos/awscd-oceania-blue-orange-rectangle.svg",
+      "tags": [
+        "awscd",
+        "blue",
+        "logo",
+        "oceania",
+        "orange",
+        "rectangle"
+      ],
+      "size": 906,
+      "description": "awscd oceania blue orange rectangle logos (906×906)"
+    },
+    {
+      "name": "awscd-oceania-blue-orange-sphere-logo",
+      "type": "logo",
+      "path": "assets/logos/awscd-oceania-blue-orange-sphere.svg",
+      "tags": [
+        "awscd",
+        "blue",
+        "logo",
+        "oceania",
+        "orange",
+        "sphere"
+      ],
+      "size": 500,
+      "description": "awscd oceania blue orange sphere logos (500×500)"
+    },
+    {
+      "name": "awscd-oceania-white-orange-icon",
+      "type": "icon",
+      "path": "assets/icons/awscd-oceania-white-orange.svg",
+      "tags": [
+        "awscd",
+        "icon",
+        "oceania",
+        "orange",
+        "white"
+      ],
+      "size": 64,
+      "description": "awscd oceania white orange icons (48×48)"
+    },
+    {
+      "name": "awscd-oceania-white-white-rectangle-logo",
+      "type": "logo",
+      "path": "assets/logos/awscd-oceania-white-white-rectangle.svg",
+      "tags": [
+        "awscd",
+        "logo",
+        "oceania",
+        "rectangle",
+        "white"
+      ],
+      "size": 906,
+      "description": "awscd oceania white white rectangle logos (906×906)"
     },
     {
       "name": "awscd-oceania-white-white-square-gray-logo",
       "type": "logo",
       "path": "assets/logos/awscd-oceania-white-white-square-gray.svg",
-      "size": 680,
-      "tags": ["aws", "logo", "oceania", "white", "square", "gray"],
-      "description": "AWS CD Oceania White Square logo with gray background #252f3e, white text and white arrow (680×280, viewBox)"
+      "tags": [
+        "awscd",
+        "gray",
+        "logo",
+        "oceania",
+        "square",
+        "white"
+      ],
+      "size": 906,
+      "description": "awscd oceania white white square gray logos (906×906)"
     },
     {
       "name": "datacom-primary-blue-logo",
       "type": "logo",
       "path": "assets/logos/datacom-primary-blue.svg",
-      "tags": ["datacom", "logo", "blue"],
-      "description": "Datacom primary logo - blue version (160x30)"
+      "tags": [
+        "blue",
+        "datacom",
+        "logo",
+        "primary"
+      ],
+      "size": 160,
+      "description": "datacom primary blue logos (160×160)"
     },
     {
       "name": "datacom-primary-white-logo",
       "type": "logo",
       "path": "assets/logos/datacom-primary-white.svg",
-      "tags": ["datacom", "logo", "white"],
-      "description": "Datacom primary logo - white background version (160x30)"
-    },
-    {
-      "name": "example-image",
-      "type": "image",
-      "path": "assets/images/example-image.png",
-      "tags": ["example", "image"],
-      "description": "Example image asset"
+      "tags": [
+        "datacom",
+        "logo",
+        "primary",
+        "white"
+      ],
+      "size": 160,
+      "description": "datacom primary white logos (160×160)"
     }
   ]
 }

--- a/scripts/generate-assets.js
+++ b/scripts/generate-assets.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Read existing assets.json to preserve custom descriptions
+let existingAssets = {};
+try {
+  const existing = JSON.parse(fs.readFileSync('assets.json', 'utf8'));
+  existing.assets.forEach(asset => {
+    existingAssets[asset.path] = asset;
+  });
+} catch (e) {
+  // File doesn't exist or is invalid, start fresh
+}
+
+const assets = [];
+
+function extractSizeFromSvg(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    // Try to extract from width/height attributes first (preferred for display size)
+    const widthMatch = content.match(/width=["'](\d+)["']/);
+    const heightMatch = content.match(/height=["'](\d+)["']/);
+    if (widthMatch && heightMatch) {
+      const width = parseInt(widthMatch[1]);
+      const height = parseInt(heightMatch[1]);
+      // Return the larger dimension, or width if square
+      return width === height ? width : Math.max(width, height);
+    }
+    // Fallback to viewBox
+    const viewBoxMatch = content.match(/viewBox=["']\d+\s+\d+\s+(\d+)\s+(\d+)["']/);
+    if (viewBoxMatch) {
+      const width = parseInt(viewBoxMatch[1]);
+      const height = parseInt(viewBoxMatch[2]);
+      return width === height ? width : Math.max(width, height);
+    }
+  } catch (e) {
+    // Ignore errors
+  }
+  return null;
+}
+
+function generateName(filename, type) {
+  // Remove extension
+  const base = filename.replace(/\.[^/.]+$/, '');
+  // Convert to kebab-case and add type suffix (singular)
+  const typeSingular = type.slice(0, -1); // Remove 's' from icons/logos/images
+  return `${base}-${typeSingular}`;
+}
+
+function extractTags(filename, type, directory) {
+  const tags = new Set();
+
+  // Add type as tag (singular)
+  const typeSingular = type.slice(0, -1); // Remove 's' from icons/logos/images
+  tags.add(typeSingular);
+
+  // Extract tags from filename (split by dashes)
+  const parts = filename.replace(/\.[^/.]+$/, '').split('-');
+  parts.forEach(part => {
+    if (part && part.length > 0) {
+      tags.add(part.toLowerCase());
+    }
+  });
+
+  // Add directory-specific tags
+  if (filename.includes('oceania')) {
+    tags.add('oceania');
+  }
+
+  return Array.from(tags).sort();
+}
+
+function generateDescription(name, type, size, filename) {
+  const typeSingular = type.slice(0, -1);
+  const existing = existingAssets[`assets/${type}/${filename}`];
+  if (existing && existing.description) {
+    return existing.description;
+  }
+
+  // Generate basic description - capitalize first letter and format nicely
+  const sizeStr = size ? ` (${size}×${size})` : '';
+  const displayName = name.replace(`-${typeSingular}`, '').split('-').map(word =>
+    word.charAt(0).toUpperCase() + word.slice(1)
+  ).join(' ');
+  return `${displayName} ${typeSingular} asset${sizeStr}`;
+}
+
+// Scan assets directory
+const assetsDir = path.join(__dirname, '..', 'assets');
+
+['icons', 'logos', 'images'].forEach(type => {
+  const typeDir = path.join(assetsDir, type);
+  if (!fs.existsSync(typeDir)) {
+    return;
+  }
+
+  const files = fs.readdirSync(typeDir);
+  files.forEach(file => {
+    const filePath = path.join(typeDir, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat.isFile()) {
+      const ext = path.extname(file).toLowerCase();
+      if (ext === '.svg' || ext === '.png' || ext === '.jpg' || ext === '.jpeg' || ext === '.webp') {
+        const relativePath = `assets/${type}/${file}`;
+        const name = generateName(file, type);
+        const size = ext === '.svg' ? extractSizeFromSvg(filePath) : null;
+        const tags = extractTags(file, type, file);
+        const description = generateDescription(name, type, size, file);
+
+        // Use singular type for the asset
+        const typeSingular = type.slice(0, -1);
+
+        const asset = {
+          name,
+          type: typeSingular,
+          path: relativePath,
+          tags
+        };
+
+        if (size) {
+          asset.size = size;
+        }
+
+        asset.description = description;
+
+        assets.push(asset);
+      }
+    }
+  });
+});
+
+// Sort assets by name
+assets.sort((a, b) => a.name.localeCompare(b.name));
+
+const output = {
+  assets
+};
+
+fs.writeFileSync('assets.json', JSON.stringify(output, null, 2) + '\n');
+console.log(`Generated assets.json with ${assets.length} assets`);


### PR DESCRIPTION
- Add scripts/generate-assets.js to automatically generate assets.json from filesystem, extracting metadata, tags, and sizes from SVG files
- Add .github/workflows/update-assets.yml to regenerate assets.json when assets change and commit updates automatically
- Update .github/workflows/pages.yml to:
  - Copy assets to root directories (icons/, logos/, images/) during deployment for direct URL access (e.g., /icons/file.svg)
  - Add fallback to generate assets.json if missing
- Regenerate assets.json with updated script output

This enables:
- Direct asset access at shorter URLs (https://assets.awsug.nz/icons/file.svg)
- Automatic assets.json updates when new files are added
- No manual maintenance of assets.json required